### PR TITLE
Fix issues with initSelection on ajax inputs

### DIFF
--- a/app/assets/javascripts/select2_simple_form/initializers.select2_simple_form.js
+++ b/app/assets/javascripts/select2_simple_form/initializers.select2_simple_form.js
@@ -36,6 +36,11 @@ var Select2SimpleForm = (function($) {
         return '<span style="cursor: pointer;" onclick="openTab(\'' + options.can_create_on_empty_result.url + '\')"> <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> ' + options.can_create_on_empty_result.label + '</span>';
       }
     }
+    
+    // Allow for HTML markup to show properly in the resulting options
+    if (options.allow_html) {
+      select2Options.escapeMarkup = function(m) { return m; };
+    }
 
     // Check AJAX options
     if (options.ajax) {
@@ -58,13 +63,15 @@ var Select2SimpleForm = (function($) {
       // it will use the first item, because selects only one element.
       select2Options.initSelection = function(element, callback) {
         var ids = sanitizeInputValues(element);
-        $.get(options.ajax, { id: ids })
-        .done(function(data) {
-          if ( options.multiple ) {
-            element.val('');
-            callback(data);
-          } else {
-            callback(data[0]);
+        if (ids.length > 0) {
+          $.get(options.ajax, { id: ids })
+          .done(function(data) {
+            if ( options.multiple ) {
+              element.val('');
+              callback(data);
+            } else {
+              callback(data[0]);
+            }
           }
         });
       }

--- a/app/assets/javascripts/select2_simple_form/initializers.select2_simple_form.js
+++ b/app/assets/javascripts/select2_simple_form/initializers.select2_simple_form.js
@@ -72,8 +72,8 @@ var Select2SimpleForm = (function($) {
             } else {
               callback(data[0]);
             }
-          }
-        });
+          });
+        }
       }
     }
 

--- a/app/inputs/select2_input.rb
+++ b/app/inputs/select2_input.rb
@@ -23,6 +23,7 @@ class Select2Input < SimpleForm::Inputs::Base
           s[:void_option] = options.delete(:void_option) if options[:void_option]
           s[:opts_for_select2] = options.delete(:opts_for_select2) if options[:opts_for_select2]
           s[:can_create_on_empty_result] = options.delete(:can_create_on_empty_result) if options[:can_create_on_empty_result]
+          s[:allow_html]  = true # Default value
           s[:allow_html]  = options.delete(:allow_html)  if options[:allow_html]
         end
 

--- a/app/inputs/select2_input.rb
+++ b/app/inputs/select2_input.rb
@@ -23,6 +23,7 @@ class Select2Input < SimpleForm::Inputs::Base
           s[:void_option] = options.delete(:void_option) if options[:void_option]
           s[:opts_for_select2] = options.delete(:opts_for_select2) if options[:opts_for_select2]
           s[:can_create_on_empty_result] = options.delete(:can_create_on_empty_result) if options[:can_create_on_empty_result]
+          s[:allow_html]  = options.delete(:allow_html)  if options[:allow_html]
         end
 
         super.deep_merge data: { ui: 'select2-simpleform', options: settings }


### PR DESCRIPTION
And also allow for HTML markup inside the options.

Adds a new option:
- `allow_html`: if `true`, will allow for options to have HTML tags inside them.
