### PR TITLE
Change select2 dependency to allow > 3.x

### DIFF
--- a/select2_simple_form.gemspec
+++ b/select2_simple_form.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails", '> 4.0.0'
-  s.add_dependency 'select2-rails', '~> 3.5.2'
+  s.add_dependency 'select2-rails', '> 3.5'
 end


### PR DESCRIPTION
`bundle install` failed with select2 4.x version. This fixes that.